### PR TITLE
Ignore caches and binaries.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 *~
 *.swp
+/version
+/cache/
+/plugins/
+/shims/
+/versions/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-*~
-*.swp
 /version
 /cache/
 /plugins/


### PR DESCRIPTION
This pull-request consists of two commits related to `.gitignore`.
### Ignore caches and binaries

Some commands like `crenv install` generate caches and binaries, but they should not be committed.
Similar tools, such as `rbenv`, also do the same thing.

In addition, this modification is convenient in the case that `crenv` is added as a subtree to the repository for user's dotfiles.
### Avoid to ignore Vim's swap and backup

The generation of these files is environment-dependent, so you might want to ignore them by using `core.excludesFile`.
