### PR TITLE
support new library path in crystal-0.20.0 (shards-0.7.0)

### DIFF
--- a/libexec/crenv-exec
+++ b/libexec/crenv-exec
@@ -43,6 +43,6 @@ done
 shift 1
 if [ "$CRENV_VERSION" != "system" ]; then
   export PATH="${CRENV_BIN_PATH}:${PATH}"
-  export CRYSTAL_PATH="${CRENV_ROOT}/versions/$(crenv-version-name)/src:libs"
+  export CRYSTAL_PATH="${CRENV_ROOT}/versions/$(crenv-version-name)/src:libs:lib"
 fi
 exec -a "$CRENV_COMMAND" "$CRENV_COMMAND_PATH" "$@"


### PR DESCRIPTION
It still fails due to lib-path problem after updating `crystal-build`.
I'm afraid that we should set `CRYSTAL_PATH` in here rather than `crystal-build`.

#### master baranch
```shell
% crystal eval 'p ENV["CRYSTAL_PATH"]'
"/home/maiha/.crenv/versions/0.20.0/src:libs"
```

#### this PR
```
% crystal eval 'p ENV["CRYSTAL_PATH"]'
"/home/maiha/.crenv/versions/0.20.0/src:libs:lib"
```

My apps work with this, at last.
Thanks.