### PR TITLE
Keep pre-defined $CRYSTAL_PATH when overriding it

### DIFF
--- a/libexec/crenv-exec
+++ b/libexec/crenv-exec
@@ -43,6 +43,7 @@ done
 shift 1
 if [ "$CRENV_VERSION" != "system" ]; then
   export PATH="${CRENV_BIN_PATH}:${PATH}"
-  export CRYSTAL_PATH="${CRENV_ROOT}/versions/$(crenv-version-name)/src:libs:lib"
+  CRYSTAL_PATH="${CRYSTAL_PATH}:${CRENV_ROOT}/versions/$(crenv-version-name)/src:libs:lib"
+  export CRYSTAL_PATH="${CRYSTAL_PATH#:}"
 fi
 exec -a "$CRENV_COMMAND" "$CRENV_COMMAND_PATH" "$@"


### PR DESCRIPTION
Fixed #23 

In mostly situations, only when targetting Crystal compiler that we need to pre-define `$CRYSTAL_PATH`, so keep it as the first path when overriding.