### PR TITLE
Release v1.1.0

### DIFF
--- a/libexec/crenv---version
+++ b/libexec/crenv---version
@@ -12,7 +12,7 @@
 set -e
 [ -n "$CRENV_DEBUG" ] && set -x
 
-version="1.0.1"
+version="1.1.0"
 git_revision=""
 
 if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q crenv; then

--- a/libexec/crenv-version-file
+++ b/libexec/crenv-version-file
@@ -64,6 +64,6 @@ else
   find_local_valid_shard_file "$CRENV_DIR" || {
     [ "$CRENV_DIR" != "$PWD" ] && find_local_version_file "$PWD"
   } || {
-    [ "$CRENV_DIR" != "$PWD" ] && find_valid_shard_file "$PWD"
+    [ "$CRENV_DIR" != "$PWD" ] && find_local_valid_shard_file "$PWD"
   } || find_global_version_file
 fi

--- a/libexec/crenv-version-file
+++ b/libexec/crenv-version-file
@@ -26,10 +26,44 @@ find_global_version_file() {
   echo "$global_version_file"
 }
 
+find_local_shard_file() {
+  local root="$1"
+  while ! [[ "$root" =~ ^//[^/]*$ ]]; do
+    if [ -e "${root}/shard.yml" ]; then
+      echo "${root}/shard.yml"
+      return 0
+    fi
+    [ -n "$root" ] || break
+    root="${root%/*}"
+  done
+  return 1
+}
+
+find_local_valid_shard_file() {
+  local root="$1"
+  local shard_file=$(find_local_shard_file $root)
+
+  if [ -z "$shard_file" ]; then
+    return 1
+  fi
+
+  local crystal_version=$(crenv-version-file-read $shard_file)
+  if [ -z "$crystal_version" ]; then
+    return 1
+  else
+    echo "$shard_file"
+    return 0
+  fi
+}
+
 if [ -n "$target_dir" ]; then
-  find_local_version_file "$target_dir"
+  find_local_version_file "$target_dir" ||
+  find_local_valid_shard_file "$target_dir"
 else
-  find_local_version_file "$CRENV_DIR" || {
+  find_local_version_file "$CRENV_DIR" ||
+  find_local_valid_shard_file "$CRENV_DIR" || {
     [ "$CRENV_DIR" != "$PWD" ] && find_local_version_file "$PWD"
+  } || {
+    [ "$CRENV_DIR" != "$PWD" ] && find_valid_shard_file "$PWD"
   } || find_global_version_file
 fi

--- a/libexec/crenv-version-file-read
+++ b/libexec/crenv-version-file-read
@@ -5,17 +5,48 @@ set -e
 
 VERSION_FILE="$1"
 
-if [ -e "$VERSION_FILE" ]; then
+read_version_file() {
+  local version_file="$1"
+
   # Read the first non-whitespace word from the specified version file.
   # Be careful not to load it whole in case there's something crazy in it.
   IFS="${IFS}"$'\r'
-  words=( $(cut -b 1-1024 "$VERSION_FILE") )
+  words=( $(cut -b 1-1024 "$version_file") )
   version="${words[0]}"
 
-  if [ -n "$version" ]; then
-    echo "$version"
-    exit
+  if [ -z "$version" ]; then
+    return 1
   fi
-fi
 
-exit 1
+  echo $version
+  return 0
+}
+
+read_shard_file() {
+  local shard_file="$1"
+
+  local version=$(cat "$shard_file" | awk '{
+    if (match($0, /^crystal:.+$/)) {
+      if (match($0, /[0-9.]+/)) {
+        print substr($0, RSTART, RLENGTH)
+      }
+    }
+  }')
+
+  if [ -z "$version" ]; then
+    return 1
+  else
+    echo $version
+    return 0
+  fi
+}
+
+if [ -e "$VERSION_FILE" ]; then
+  if [[ "$VERSION_FILE" =~ shard\.yml$ ]]; then
+    read_shard_file "$VERSION_FILE"
+  else
+    read_version_file "$VERSION_FILE"
+  fi
+else
+  exit 1
+fi

--- a/test/version-file-read.bats
+++ b/test/version-file-read.bats
@@ -70,3 +70,27 @@ IN
   run crenv-version-file-read my-version
   assert_success "1.9.3"
 }
+
+@test "reads shard.yml version file" {
+  cat > shard.yml <<< "crystal: 0.20.1"
+  run crenv-version-file-read shard.yml
+  assert_success "0.20.1"
+}
+
+@test "reads shard.yml version file (single quoted)" {
+  cat > shard.yml <<< "crystal: '0.20.1'"
+  run crenv-version-file-read shard.yml
+  assert_success "0.20.1"
+}
+
+@test "reads shard.yml version file (double quoted)" {
+  cat > shard.yml <<< "crystal: \"0.20.1\""
+  run crenv-version-file-read shard.yml
+  assert_success "0.20.1"
+}
+
+@test "reads invalid shard.yml version file" {
+  touch "shard.yml"
+  run crenv-version-file-read shard.yml
+  assert_failure ""
+}

--- a/test/version-file.bats
+++ b/test/version-file.bats
@@ -31,6 +31,25 @@ create_file() {
   assert_success "${CRENV_TEST_DIR}/.crystal-version"
 }
 
+@test "in current directory (shard.yml)" {
+  assert [ ! -e "${CRENV_ROOT}/version" ]
+  assert [ ! -e ".crystal-version" ]
+
+  create_file "project/shard.yml"
+  cd project
+  cat > shard.yml <<< "crystal: 0.20.1"
+  run crenv-version-file
+  assert_success "${CRENV_TEST_DIR}/project/shard.yml"
+}
+
+@test "in current directory but invalid file (shard.yml)" {
+  create_file "project/shard.yml"
+  cd project
+  cat > shard.yml <<< "name: foo"
+  run crenv-version-file
+  assert_success "${CRENV_ROOT}/version"
+}
+
 @test "legacy file in current directory" {
   create_file ".crenv-version"
   run crenv-version-file
@@ -44,12 +63,37 @@ create_file() {
   assert_success "${CRENV_TEST_DIR}/.crystal-version"
 }
 
+@test ".crystal-version has precedence over shard.yml file" {
+  create_file ".crystal-version"
+  create_file "shard.yml"
+  cat > shard.yml <<< "crystal: 0.20.1"
+  run crenv-version-file
+  assert_success "${CRENV_TEST_DIR}/.crystal-version"
+}
+
+@test "shard.yml has precedence over global version" {
+  create_file "${CRENV_ROOT}/version"
+  create_file "shard.yml"
+  cat > shard.yml <<< "crystal: 0.20.1"
+  run crenv-version-file
+  assert_success "${CRENV_TEST_DIR}/shard.yml"
+}
+
 @test "in parent directory" {
   create_file ".crystal-version"
   mkdir -p project
   cd project
   run crenv-version-file
   assert_success "${CRENV_TEST_DIR}/.crystal-version"
+}
+
+@test "in parent directory (shard.yml)" {
+  create_file "shard.yml"
+  cat > shard.yml <<< "crystal: 0.20.1"
+  mkdir -p project
+  cd project
+  run crenv-version-file
+  assert_success "${CRENV_TEST_DIR}/shard.yml"
 }
 
 @test "topmost file has precedence" {
@@ -60,12 +104,40 @@ create_file() {
   assert_success "${CRENV_TEST_DIR}/project/.crystal-version"
 }
 
+@test "topmost file has precedence (shard.yml)" {
+  create_file "shard.yml"
+  create_file "project/shard.yml"
+  cat > "shard.yml" <<< "crystal: 0.20.1"
+  cat > "project/shard.yml" <<< "crystal: 0.20.1"
+  cd project
+  run crenv-version-file
+  assert_success "${CRENV_TEST_DIR}/project/shard.yml"
+}
+
 @test "legacy file has precedence if higher" {
   create_file ".crystal-version"
   create_file "project/.crenv-version"
   cd project
   run crenv-version-file
   assert_success "${CRENV_TEST_DIR}/project/.crenv-version"
+}
+
+@test "legacy file has precedence if higher (shard.yml)" {
+  create_file "shard.yml"
+  create_file "project/.crenv-version"
+  cat > "shard.yml" <<< "crystal: 0.20.1"
+  cd project
+  run crenv-version-file
+  assert_success "${CRENV_TEST_DIR}/project/.crenv-version"
+}
+
+@test ".crystal-version file has precedence if higher (shard.yml)" {
+  create_file "shard.yml"
+  create_file "project/.crystal-version"
+  cat > "shard.yml" <<< "crystal: 0.20.1"
+  cd project
+  run crenv-version-file
+  assert_success "${CRENV_TEST_DIR}/project/.crystal-version"
 }
 
 @test "CRENV_DIR has precedence over PWD" {
@@ -76,10 +148,39 @@ create_file() {
   assert_success "${CRENV_TEST_DIR}/widget/.crystal-version"
 }
 
+@test "CRENV_DIR has precedence over PWD (shard.yml)" {
+  create_file "widget/shard.yml"
+  create_file "project/shard.yml"
+  cat > "widget/shard.yml" <<< "crystal: 0.20.1"
+  cat > "project/shard.yml" <<< "crystal: 0.20.1"
+  cd project
+  CRENV_DIR="${CRENV_TEST_DIR}/widget" run crenv-version-file
+  assert_success "${CRENV_TEST_DIR}/widget/shard.yml"
+}
+
+@test "CRENV_DIR has precedence over PWD (invalid shard.yml file)" {
+  create_file "widget/shard.yml"
+  create_file "project/shard.yml"
+  cat > "widget/shard.yml" <<< "name: foo"
+  cat > "project/shard.yml" <<< "crystal: 0.20.1"
+  cd project
+  CRENV_DIR="${CRENV_TEST_DIR}/widget" run crenv-version-file
+  assert_success "${CRENV_TEST_DIR}/project/shard.yml"
+}
+
 @test "PWD is searched if CRENV_DIR yields no results" {
   mkdir -p "widget/blank"
   create_file "project/.crystal-version"
   cd project
   CRENV_DIR="${CRENV_TEST_DIR}/widget/blank" run crenv-version-file
   assert_success "${CRENV_TEST_DIR}/project/.crystal-version"
+}
+
+@test "PWD is searched if CRENV_DIR yields no results (shard.yml)" {
+  mkdir -p "widget/blank"
+  create_file "project/shard.yml"
+  cat > "project/shard.yml" <<< "crystal: 0.20.1"
+  cd project
+  CRENV_DIR="${CRENV_TEST_DIR}/widget/blank" run crenv-version-file
+  assert_success "${CRENV_TEST_DIR}/project/shard.yml"
 }


### PR DESCRIPTION
- Support `shard.yml` file
  - If your `shard.yml` has `crystal` version field, crenv use it.
  - Detecting priority: `.crystal-version` > `shard.yml` > global crenv Crystal version
  - But YAML parser is not parfect.