### PR TITLE
Fix variable exports for fish shell

### DIFF
--- a/libexec/crenv-init
+++ b/libexec/crenv-init
@@ -71,8 +71,8 @@ mkdir -p "${CRENV_ROOT}/"{shims,versions}
 
 case "$shell" in
 fish )
-  echo "setenv PATH '${CRENV_ROOT}/shims' \$PATH"
-  echo "setenv CRENV_SHELL $shell"
+  echo "set -gx PATH '${CRENV_ROOT}/shims' \$PATH"
+  echo "set -gx CRENV_SHELL $shell"
 ;;
 * )
   echo 'export PATH="'${CRENV_ROOT}'/shims:${PATH}"'

--- a/libexec/crenv-sh-shell
+++ b/libexec/crenv-sh-shell
@@ -52,7 +52,7 @@ fi
 if crenv-prefix "$version" >/dev/null; then
   case "$shell" in
   fish )
-    echo "setenv CRENV_VERSION \"${version}\""
+    echo "set -gx CRENV_VERSION \"${version}\""
     ;;
   * )
     echo "export CRENV_VERSION=\"${version}\""

--- a/test/init.bats
+++ b/test/init.bats
@@ -61,7 +61,7 @@ load test_helper
   export PATH="${BATS_TEST_DIRNAME}/../libexec:/usr/bin:/bin:/usr/local/bin"
   run crenv-init - fish
   assert_success
-  assert_line 0 "setenv PATH '${CRENV_ROOT}/shims' \$PATH"
+  assert_line 0 "set -gx PATH '${CRENV_ROOT}/shims' \$PATH"
 }
 
 @test "can add shims to PATH more than once" {
@@ -75,7 +75,7 @@ load test_helper
   export PATH="${CRENV_ROOT}/shims:$PATH"
   run crenv-init - fish
   assert_success
-  assert_line 0 "setenv PATH '${CRENV_ROOT}/shims' \$PATH"
+  assert_line 0 "set -gx PATH '${CRENV_ROOT}/shims' \$PATH"
 }
 
 @test "outputs sh-compatible syntax" {

--- a/test/shell.bats
+++ b/test/shell.bats
@@ -48,5 +48,5 @@ SH
 @test "shell change version (fish)" {
   mkdir -p "${CRENV_ROOT}/versions/1.2.3"
   CRENV_SHELL=fish run crenv-sh-shell 1.2.3
-  assert_success 'setenv CRENV_VERSION "1.2.3"'
+  assert_success 'set -gx CRENV_VERSION "1.2.3"'
 }


### PR DESCRIPTION
Use `set -gx` instead of `setenv`, because `setenv` is just a wrapper
function that seems to be pretty error prone.