### PR TITLE
Look for CRYSTAL_PATH in prefix/share/crystal/src as well

### DIFF
--- a/libexec/crenv-exec
+++ b/libexec/crenv-exec
@@ -43,7 +43,7 @@ done
 shift 1
 if [ "$CRENV_VERSION" != "system" ]; then
   export PATH="${CRENV_BIN_PATH}:${PATH}"
-  CRYSTAL_PATH="${CRYSTAL_PATH}:${CRENV_ROOT}/versions/$(crenv-version-name)/src:libs:lib"
+  CRYSTAL_PATH="${CRYSTAL_PATH}:$(crenv-prefix)/share/crystal/src:$(crenv-prefix)/src:libs:lib"
   export CRYSTAL_PATH="${CRYSTAL_PATH#:}"
 fi
 exec -a "$CRENV_COMMAND" "$CRENV_COMMAND_PATH" "$@"


### PR DESCRIPTION
Crystal 0.24.1 (at least) does not place the src dir directly in
crenv prefix, but in prefix/share/crystal/src. This adds the former
in the CRYSTAL_PATH so compiling works.