### PR TITLE
Use GIT_CONFIG in tests

### DIFF
--- a/test/crenv-version.bats
+++ b/test/crenv-version.bats
@@ -4,10 +4,13 @@ load test_helper
 
 export GIT_DIR="${CRENV_TEST_DIR}/.git"
 
+# points to /tmp/crenv/home/.gitconfig
+export GIT_CONFIG="$HOME/.gitconfig"
+
 setup() {
   mkdir -p "$HOME"
-  git config --global user.name  "Tester"
-  git config --global user.email "tester@test.local"
+  git config user.name  "Tester"
+  git config user.email "tester@test.local"
   cd "$CRENV_TEST_DIR"
 }
 


### PR DESCRIPTION
When running the `bats` tests the user's global configuration is being overwritten.

This is annoying and could lead to a wrong email and username in future commits in other projects if one doesn't check his git log after committing locally.

Setting the `GIT_CONFIG` environment variable points git to a different config location to use instead.